### PR TITLE
test: fix broken test caused by incorrectly ordered inequality

### DIFF
--- a/authorization/service_account_provider_test.go
+++ b/authorization/service_account_provider_test.go
@@ -51,8 +51,8 @@ func TestTokenSource_Token(t *testing.T) {
 	assert.Equal(t, "https://firestore.googleapis.com/", claims["aud"])
 
 	// Issued time is between the start of the test and now
-	assert.GreaterOrEqual(t, testStartTime, claims["iat"])
-	assert.LessOrEqual(t, float64(time.Now().Unix()), claims["iat"])
+	assert.GreaterOrEqual(t, claims["iat"], testStartTime)
+	assert.LessOrEqual(t, claims["iat"], float64(time.Now().Unix()))
 
 	// Expiration time is one hour after issued time
 	assert.Equal(t, claims["iat"].(float64)+3600, claims["exp"])


### PR DESCRIPTION
Assert that the issued time is _after_ the test start time but _before_ the current time.