### PR TITLE
feat: add support for creating new users

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,10 +31,9 @@ func main() {
 		developer_id,
 	)
 
-	users, err := users.ListUsers(client, context.Background(), url)
+	usersList, err := users.List(client, context.Background(), url)
 	check(err)
-
-	fmt.Println("Hello World", users)
+	fmt.Println("User list: ", usersList)
 }
 
 func check(e error) {

--- a/users/create.go
+++ b/users/create.go
@@ -1,0 +1,40 @@
+package users
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"googleplay-go/networking"
+	"net/http"
+)
+
+func Create(c networking.HTTPClient, ctx context.Context, url string, user User) (*User, error) {
+	body := bytes.NewBuffer(nil)
+	err := json.NewEncoder(body).Encode(user)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request body: %w", err)
+	}
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	newUser := new(User)
+	if err := json.NewDecoder(resp.Body).Decode(newUser); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	return newUser, nil
+}

--- a/users/create_test.go
+++ b/users/create_test.go
@@ -1,0 +1,66 @@
+package users
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateUsers_MakesRequest(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{ }`,
+	}
+
+	user := User{
+		Name:                       "John Doe",
+		Email:                      "john.doe@example.com",
+		DeveloperAccountPermission: []DeveloperLevelPermission{"CAN_MANAGE_PERMISSIONS_GLOBAL"},
+	}
+
+	_, _ = Create(
+		httpClient, context.Background(), "https://example.com",
+		user,
+	)
+
+	assert.Equal(t, len(httpClient.requests), 1)
+	assert.Equal(t, httpClient.requests[0].Method, "POST")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com")
+
+	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
+	assert.NoError(t, err)
+	bodyString := string(bodyBytes)
+	assert.Equal(t, bodyString,
+		`{"name":"John Doe","email":"john.doe@example.com","developerAccountPermissions":["CAN_MANAGE_PERMISSIONS_GLOBAL"]}
+`)
+}
+
+func TestCreateUsers_DecodesResponse(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{
+			"name": "John Doe",
+			"email": "john.doe@example.com",
+			"accessState": "INVITED",
+			"partial": false,
+			"developerAccountPermissions": [
+				"CAN_REPLY_TO_REVIEWS_GLOBAL"
+			]
+		}`,
+	}
+
+	user := User{}
+
+	createdUser, err := Create(
+		httpClient, context.Background(), "https://example.com",
+		user,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, createdUser.Name, "John Doe")
+	assert.Equal(t, createdUser.Email, "john.doe@example.com")
+	assert.Equal(t, createdUser.AccessState, Invited)
+	assert.Equal(t, createdUser.Partial, false)
+	assert.Equal(t, createdUser.DeveloperAccountPermission, []DeveloperLevelPermission{"CAN_REPLY_TO_REVIEWS_GLOBAL"})
+
+}

--- a/users/list.go
+++ b/users/list.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 )
 
-func ListUsers(c networking.HTTPClient, ctx context.Context, rawURL string) ([]User, error) {
+func List(c networking.HTTPClient, ctx context.Context, rawURL string) ([]User, error) {
 	// Parse the raw URL
 	parsedURL, err := url.Parse(rawURL)
 	if err != nil {

--- a/users/list_test.go
+++ b/users/list_test.go
@@ -20,7 +20,7 @@ func TestListUsers_MakesRequest(t *testing.T) {
 		}`,
 	}
 
-	_, _ = ListUsers(
+	_, _ = List(
 		httpClient, context.Background(), "https://example.com",
 	)
 
@@ -46,7 +46,7 @@ func TestListUsers_DecodesResponse(t *testing.T) {
 		}`,
 	}
 
-	users, _ := ListUsers(
+	users, _ := List(
 		httpClient, context.Background(), "https://example.com",
 	)
 

--- a/users/user.go
+++ b/users/user.go
@@ -3,7 +3,8 @@ package users
 type User struct {
 	Name                       string                     `json:"name"`
 	Email                      string                     `json:"email"`
-	AccessState                AccessState                `json:"accessState"`
 	DeveloperAccountPermission []DeveloperLevelPermission `json:"developerAccountPermissions"`
-	PrimaryLocale              []Grant                    `json:"grants"`
+	Partial                    bool                       `json:"partial,omitempty"`
+	AccessState                AccessState                `json:"accessState,omitempty"`
+	PrimaryLocale              []Grant                    `json:"grants,omitempty"`
 }


### PR DESCRIPTION
Add support for creating new users in the Google Play Console:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/a7035e03-1905-4874-a829-c314eb18efd2" />


```bash
Created user:  &{developers/5166846112789481453/users/john.doe@oliverbinns.co.uk john.doe@oliverbinns.co.uk [CAN_REPLY_TO_REVIEWS_GLOBAL] false INVITED []}
```