### PR TITLE
feat: delete users from Google Play Console

### DIFF
--- a/networking/http_client.go
+++ b/networking/http_client.go
@@ -38,7 +38,7 @@ func (c *authorizedClient) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 

--- a/networking/http_client_test.go
+++ b/networking/http_client_test.go
@@ -24,6 +24,19 @@ func TestNewAuthorizedClient_AuthorizationHeaderIsSet(t *testing.T) {
 	)
 }
 
+func TestNewAuthorizedClient_Allows2XXStatusCodes(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		statusCode: http.StatusNoContent,
+	}
+	tokenSource := &mockTokenSource{}
+
+	authorizedClient := NewAuthorizedClient(httpClient, tokenSource)
+	req, _ := http.NewRequest("GET", "https://example.com", nil)
+	_, err := authorizedClient.Do(req)
+
+	assert.NoError(t, err)
+}
+
 func TestNewAuthorizedClient_ThrowsErrorForUnexpectedStatusCode(t *testing.T) {
 	httpClient := &mockHTTPClient{
 		statusCode: http.StatusUnauthorized,

--- a/users/create_test.go
+++ b/users/create_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateUsers_MakesRequest(t *testing.T) {
+func TestCreateUser_MakesRequest(t *testing.T) {
 	httpClient := &mockHTTPClient{
 		response: `{ }`,
 	}
@@ -36,7 +36,7 @@ func TestCreateUsers_MakesRequest(t *testing.T) {
 `)
 }
 
-func TestCreateUsers_DecodesResponse(t *testing.T) {
+func TestCreateUser_DecodesResponse(t *testing.T) {
 	httpClient := &mockHTTPClient{
 		response: `{
 			"name": "John Doe",

--- a/users/delete.go
+++ b/users/delete.go
@@ -1,0 +1,30 @@
+package users
+
+import (
+	"context"
+	"fmt"
+	"googleplay-go/networking"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+func Delete(c networking.HTTPClient, ctx context.Context, baseURL string, email string) error {
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse URL: %w", err)
+	}
+	parsedURL.Path = path.Join(parsedURL.Path, email)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, parsedURL.String(), http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	_, err = c.Do(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/users/delete_test.go
+++ b/users/delete_test.go
@@ -1,0 +1,41 @@
+package users
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteUser_MakesRequest(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{ }`,
+	}
+
+	_ = Delete(
+		httpClient, context.Background(), "https://example.com",
+		"john.doe@example.com",
+	)
+
+	assert.Equal(t, len(httpClient.requests), 1)
+	assert.Equal(t, httpClient.requests[0].Method, "DELETE")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/john.doe@example.com")
+	assert.Equal(t, httpClient.requests[0].Body, http.NoBody)
+}
+
+func TestDeleteUser_IsSuccessful(t *testing.T) {
+	code := http.StatusNoContent
+
+	httpClient := &mockHTTPClient{
+		statusCode: &code,
+		response:   `{ }`,
+	}
+
+	err := Delete(
+		httpClient, context.Background(), "https://example.com",
+		"john.doe@example.com",
+	)
+
+	assert.NoError(t, err)
+}

--- a/users/list_test.go
+++ b/users/list_test.go
@@ -60,6 +60,8 @@ func TestListUsers_DecodesResponse(t *testing.T) {
 type mockHTTPClient struct {
 	requests []*http.Request
 	response string
+
+	statusCode *int
 }
 
 func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
@@ -67,8 +69,13 @@ func (c *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
 
 	responseBody := io.NopCloser(bytes.NewReader([]byte(c.response)))
 
+	status := http.StatusOK
+	if c.statusCode != nil {
+		status = *c.statusCode
+	}
+
 	return &http.Response{
-		StatusCode: http.StatusOK,
+		StatusCode: status,
 		Body:       responseBody,
 	}, nil
 }


### PR DESCRIPTION
Add support for deleting users from the Google Play Console:

```bash
oliver@Olivers-MacBook-Air googleplay-go % go run main.go "/Users/oliver/Downloads/seraphic-elixir-305011-46b707d0e1d9.json" "5166846112789481453"
User list:  [{developers/5166846112789481453/users/google-play-console@seraphic-elixir-305011.iam.gserviceaccount.com google-play-console@seraphic-elixir-305011.iam.gserviceaccount.com [CAN_VIEW_FINANCIAL_DATA_GLOBAL CAN_MANAGE_PERMISSIONS_GLOBAL CAN_EDIT_GAMES_GLOBAL CAN_PUBLISH_GAMES_GLOBAL CAN_REPLY_TO_REVIEWS_GLOBAL CAN_MANAGE_PUBLIC_APKS_GLOBAL CAN_MANAGE_TRACK_APKS_GLOBAL CAN_MANAGE_TRACK_USERS_GLOBAL CAN_MANAGE_PUBLIC_LISTING_GLOBAL CAN_MANAGE_DRAFT_APPS_GLOBAL CAN_CREATE_MANAGED_PLAY_APPS_GLOBAL CAN_MANAGE_ORDERS_GLOBAL CAN_MANAGE_APP_CONTENT_GLOBAL CAN_VIEW_NON_FINANCIAL_DATA_GLOBAL CAN_VIEW_APP_QUALITY_GLOBAL CAN_MANAGE_DEEPLINKS_GLOBAL] false ACCESS_GRANTED []} {developers/5166846112789481453/users/mail@oliverbinns.info mail@oliverbinns.info [CAN_MANAGE_PERMISSIONS_GLOBAL] false ACCESS_GRANTED []}]
Created user:  &{developers/5166846112789481453/users/john.doe@oliverbinns.co.uk john.doe@oliverbinns.co.uk [CAN_REPLY_TO_REVIEWS_GLOBAL] false INVITED []}
Deleted user:  john.doe@oliverbinns.co.uk
```