### PR TITLE
chore!: update package name to include github.com

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module googleplay-go
+module github.com/oliver-binns/googleplay-go
 
 go 1.22
 

--- a/main.go
+++ b/main.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"googleplay-go/authorization"
-	"googleplay-go/networking"
-	"googleplay-go/users"
 	"net/http"
 	"os"
+
+	"github.com/oliver-binns/googleplay-go/authorization"
+	"github.com/oliver-binns/googleplay-go/networking"
+	"github.com/oliver-binns/googleplay-go/users"
 )
 
 func main() {
@@ -34,6 +35,22 @@ func main() {
 	usersList, err := users.List(client, context.Background(), url)
 	check(err)
 	fmt.Println("User list: ", usersList)
+
+	newUserRequest := users.User{
+		Name:  "John Doe",
+		Email: "john.doe@oliverbinns.co.uk",
+		DeveloperAccountPermission: []users.DeveloperLevelPermission{
+			users.CanReplyToReviewsGlobal,
+		},
+	}
+
+	newUser, err := users.Create(client, context.Background(), url, newUserRequest)
+	check(err)
+	fmt.Println("Created user: ", newUser)
+
+	err = users.Delete(client, context.Background(), url, newUser.Email)
+	check(err)
+	fmt.Println("Deleted user: ", newUser.Email)
 }
 
 func check(e error) {

--- a/users/create.go
+++ b/users/create.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"googleplay-go/networking"
 	"net/http"
+
+	"github.com/oliver-binns/googleplay-go/networking"
 )
 
 func Create(c networking.HTTPClient, ctx context.Context, url string, user User) (*User, error) {

--- a/users/delete.go
+++ b/users/delete.go
@@ -3,10 +3,11 @@ package users
 import (
 	"context"
 	"fmt"
-	"googleplay-go/networking"
 	"net/http"
 	"net/url"
 	"path"
+
+	"github.com/oliver-binns/googleplay-go/networking"
 )
 
 func Delete(c networking.HTTPClient, ctx context.Context, baseURL string, email string) error {

--- a/users/list.go
+++ b/users/list.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"googleplay-go/networking"
 	"net/http"
 	"net/url"
+
+	"github.com/oliver-binns/googleplay-go/networking"
 )
 
 func List(c networking.HTTPClient, ctx context.Context, rawURL string) ([]User, error) {


### PR DESCRIPTION
Update package name to `github.com/oliver-binns/googleplay-go`.
This enables the package to be easily imported into other Go projects.