### PR TITLE
fix: expose implementation details to workaround Terraform issue

### DIFF
--- a/networking/http_client.go
+++ b/networking/http_client.go
@@ -13,19 +13,19 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-type authorizedClient struct {
+type AuthorizedClient struct {
 	httpClient  HTTPClient
 	tokenSource TokenSource
 }
 
 func NewAuthorizedClient(httpClient HTTPClient, tokenSource TokenSource) HTTPClient {
-	return &authorizedClient{
+	return &AuthorizedClient{
 		httpClient:  httpClient,
 		tokenSource: tokenSource,
 	}
 }
 
-func (c *authorizedClient) Do(req *http.Request) (*http.Response, error) {
+func (c *AuthorizedClient) Do(req *http.Request) (*http.Response, error) {
 	token, err := c.tokenSource.Token()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get token: %w", err)


### PR DESCRIPTION
Working around a Terraform issue where the interface cannot be unwrapped but the concrete type can:

```
=== RUN   TestAccUsersDataSource
log: &{0x103b530a0 0x140003399e0}
panic: interface conversion: interface {} is *networking.authorizedClient, not *networking.HTTPClient
```