### PR TITLE
feat: add support for updating users

### DIFF
--- a/client.go
+++ b/client.go
@@ -64,7 +64,6 @@ func (c *Client) CreateUser(
 
 func (c *Client) UpdateUser(
 	email string,
-	name *string,
 	permissions *[]users.DeveloperLevelPermission,
 	ctx context.Context,
 ) (*users.User, error) {
@@ -73,7 +72,7 @@ func (c *Client) UpdateUser(
 		c.developerID,
 	)
 
-	return users.Update(*c.client, ctx, url, email, name, permissions)
+	return users.Update(*c.client, ctx, url, email, permissions)
 }
 
 func (c *Client) DeleteUser(email string, ctx context.Context) error {

--- a/client.go
+++ b/client.go
@@ -33,23 +33,20 @@ func GooglePlayClient(developerID string, serviceAccountJson string) *Client {
 	}
 }
 
-func (c *Client) ListUsers() ([]users.User, error) {
+func (c *Client) ListUsers(ctx context.Context) ([]users.User, error) {
 	url := fmt.Sprintf(
 		"https://androidpublisher.googleapis.com/androidpublisher/v3/developers/%s/users",
 		c.developerID,
 	)
 
-	usersList, err := users.List(*c.client, context.Background(), url)
-	if err != nil {
-		return nil, err
-	}
-	return usersList, nil
+	return users.List(*c.client, ctx, url)
 }
 
 func (c *Client) CreateUser(
 	name string,
 	email string,
 	permission []users.DeveloperLevelPermission,
+	ctx context.Context,
 ) (*users.User, error) {
 	url := fmt.Sprintf(
 		"https://androidpublisher.googleapis.com/androidpublisher/v3/developers/%s/users",
@@ -57,29 +54,35 @@ func (c *Client) CreateUser(
 	)
 
 	newUserRequest := users.User{
-		Name:                       name,
-		Email:                      email,
-		DeveloperAccountPermission: permission,
+		Name:                        name,
+		Email:                       email,
+		DeveloperAccountPermissions: permission,
 	}
 
-	newUser, err := users.Create(*c.client, context.Background(), url, newUserRequest)
-	if err != nil {
-		return nil, err
-	}
-	return newUser, nil
+	return users.Create(*c.client, ctx, url, newUserRequest)
 }
 
-func (c *Client) DeleteUser(email string) error {
+func (c *Client) UpdateUser(
+	email string,
+	ctx context.Context,
+	name *string,
+	permissions *[]users.DeveloperLevelPermission,
+) (*users.User, error) {
 	url := fmt.Sprintf(
 		"https://androidpublisher.googleapis.com/androidpublisher/v3/developers/%s/users",
 		c.developerID,
 	)
 
-	err := users.Delete(*c.client, context.Background(), url, email)
-	if err != nil {
-		return err
-	}
-	return nil
+	return users.Update(*c.client, ctx, url, name, permissions)
+}
+
+func (c *Client) DeleteUser(email string, ctx context.Context) error {
+	url := fmt.Sprintf(
+		"https://androidpublisher.googleapis.com/androidpublisher/v3/developers/%s/users",
+		c.developerID,
+	)
+
+	return users.Delete(*c.client, ctx, url, email)
 }
 
 func check(e error) {

--- a/client.go
+++ b/client.go
@@ -64,9 +64,9 @@ func (c *Client) CreateUser(
 
 func (c *Client) UpdateUser(
 	email string,
-	ctx context.Context,
 	name *string,
 	permissions *[]users.DeveloperLevelPermission,
+	ctx context.Context,
 ) (*users.User, error) {
 	url := fmt.Sprintf(
 		"https://androidpublisher.googleapis.com/androidpublisher/v3/developers/%s/users",

--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ func (c *Client) UpdateUser(
 		c.developerID,
 	)
 
-	return users.Update(*c.client, ctx, url, name, permissions)
+	return users.Update(*c.client, ctx, url, email, name, permissions)
 }
 
 func (c *Client) DeleteUser(email string, ctx context.Context) error {

--- a/users/create_test.go
+++ b/users/create_test.go
@@ -14,9 +14,9 @@ func TestCreateUser_MakesRequest(t *testing.T) {
 	}
 
 	user := User{
-		Name:                       "John Doe",
-		Email:                      "john.doe@example.com",
-		DeveloperAccountPermission: []DeveloperLevelPermission{"CAN_MANAGE_PERMISSIONS_GLOBAL"},
+		Name:                        "John Doe",
+		Email:                       "john.doe@example.com",
+		DeveloperAccountPermissions: []DeveloperLevelPermission{"CAN_MANAGE_PERMISSIONS_GLOBAL"},
 	}
 
 	_, _ = Create(
@@ -61,6 +61,6 @@ func TestCreateUser_DecodesResponse(t *testing.T) {
 	assert.Equal(t, createdUser.Email, "john.doe@example.com")
 	assert.Equal(t, createdUser.AccessState, Invited)
 	assert.Equal(t, createdUser.Partial, false)
-	assert.Equal(t, createdUser.DeveloperAccountPermission, []DeveloperLevelPermission{"CAN_REPLY_TO_REVIEWS_GLOBAL"})
+	assert.Equal(t, createdUser.DeveloperAccountPermissions, []DeveloperLevelPermission{"CAN_REPLY_TO_REVIEWS_GLOBAL"})
 
 }

--- a/users/update.go
+++ b/users/update.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/oliver-binns/googleplay-go/networking"
@@ -16,6 +17,7 @@ func Update(
 	c networking.HTTPClient,
 	ctx context.Context,
 	rawURL string,
+	email string,
 	name *string,
 	permissions *[]DeveloperLevelPermission,
 ) (*User, error) {
@@ -24,6 +26,7 @@ func Update(
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse URL: %w", err)
 	}
+	parsedURL.Path = path.Join(parsedURL.Path, email)
 
 	updateMask := []string{}
 

--- a/users/update.go
+++ b/users/update.go
@@ -18,7 +18,6 @@ func Update(
 	ctx context.Context,
 	rawURL string,
 	email string,
-	name *string,
 	permissions *[]DeveloperLevelPermission,
 ) (*User, error) {
 	// Parse the raw URL
@@ -31,10 +30,6 @@ func Update(
 	updateMask := []string{}
 
 	user := UserUpdateRequest{}
-	if name != nil {
-		updateMask = append(updateMask, "name")
-		user.Name = *name
-	}
 
 	if permissions != nil {
 		updateMask = append(updateMask, "developerAccountPermissions")
@@ -77,6 +72,5 @@ func Update(
 }
 
 type UserUpdateRequest struct {
-	Name                        string                     `json:"name,omitempty"`
 	DeveloperAccountPermissions []DeveloperLevelPermission `json:"developerAccountPermissions,omitempty"`
 }

--- a/users/update.go
+++ b/users/update.go
@@ -1,0 +1,79 @@
+package users
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/oliver-binns/googleplay-go/networking"
+)
+
+func Update(
+	c networking.HTTPClient,
+	ctx context.Context,
+	rawURL string,
+	name *string,
+	permissions *[]DeveloperLevelPermission,
+) (*User, error) {
+	// Parse the raw URL
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	updateMask := []string{}
+
+	user := UserUpdateRequest{}
+	if name != nil {
+		updateMask = append(updateMask, "name")
+		user.Name = *name
+	}
+
+	if permissions != nil {
+		updateMask = append(updateMask, "developerAccountPermissions")
+		user.DeveloperAccountPermissions = *permissions
+	}
+
+	body := bytes.NewBuffer(nil)
+	err = json.NewEncoder(body).Encode(user)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode request body: %w", err)
+	}
+
+	// Add the "updateMask" query parameter
+	// This is a comma-separated list of fields to be updated
+	query := parsedURL.Query()
+	query.Set("updateMask", strings.Join(updateMask, ","))
+	parsedURL.RawQuery = query.Encode()
+
+	// Create the HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, parsedURL.String(), body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	newUser := new(User)
+	if err := json.NewDecoder(resp.Body).Decode(newUser); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	if err := resp.Body.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close response body: %w", err)
+	}
+
+	return newUser, nil
+}
+
+type UserUpdateRequest struct {
+	Name                        string                     `json:"name,omitempty"`
+	DeveloperAccountPermissions []DeveloperLevelPermission `json:"developerAccountPermissions,omitempty"`
+}

--- a/users/update_test.go
+++ b/users/update_test.go
@@ -15,13 +15,14 @@ func TestUpdateUsers_MakesRequestWithNoValues(t *testing.T) {
 
 	_, _ = Update(
 		httpClient, context.Background(), "https://example.com",
+		"example@oliverbinns.co.uk",
 		nil,
 		nil,
 	)
 
 	assert.Equal(t, len(httpClient.requests), 1)
 	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
-	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com?updateMask=")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/example@oliverbinns.co.uk?updateMask=")
 
 	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
 	assert.NoError(t, err)
@@ -39,13 +40,14 @@ func TestUpdateUsers_MakesRequestWithName(t *testing.T) {
 	name := "John Doe"
 	_, _ = Update(
 		httpClient, context.Background(), "https://example.com",
+		"example@oliverbinns.co.uk",
 		&name,
 		nil,
 	)
 
 	assert.Equal(t, len(httpClient.requests), 1)
 	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
-	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com?updateMask=name")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/example@oliverbinns.co.uk?updateMask=name")
 
 	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
 	assert.NoError(t, err)
@@ -66,13 +68,14 @@ func TestUpdateUsers_MakesRequestWithPermissions(t *testing.T) {
 	}
 	_, _ = Update(
 		httpClient, context.Background(), "https://example.com",
+		"example@oliverbinns.co.uk",
 		nil,
 		&permissions,
 	)
 
 	assert.Equal(t, len(httpClient.requests), 1)
 	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
-	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com?updateMask=developerAccountPermissions")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/example@oliverbinns.co.uk?updateMask=developerAccountPermissions")
 
 	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
 	assert.NoError(t, err)
@@ -94,13 +97,14 @@ func TestUpdateUsers_MakesRequestWithAllParameters(t *testing.T) {
 	}
 	_, _ = Update(
 		httpClient, context.Background(), "https://example.com",
+		"example@oliverbinns.co.uk",
 		&name,
 		&permissions,
 	)
 
 	assert.Equal(t, len(httpClient.requests), 1)
 	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
-	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com?updateMask=name%2CdeveloperAccountPermissions")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/example@oliverbinns.co.uk?updateMask=name%2CdeveloperAccountPermissions")
 
 	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
 	assert.NoError(t, err)
@@ -124,6 +128,7 @@ func TestUpdateUsers_DecodesResponse(t *testing.T) {
 
 	user, _ := Update(
 		httpClient, context.Background(), "https://example.com",
+		"mail@oliverbinns.co.uk",
 		nil,
 		nil,
 	)

--- a/users/update_test.go
+++ b/users/update_test.go
@@ -17,7 +17,6 @@ func TestUpdateUsers_MakesRequestWithNoValues(t *testing.T) {
 		httpClient, context.Background(), "https://example.com",
 		"example@oliverbinns.co.uk",
 		nil,
-		nil,
 	)
 
 	assert.Equal(t, len(httpClient.requests), 1)
@@ -29,31 +28,6 @@ func TestUpdateUsers_MakesRequestWithNoValues(t *testing.T) {
 	bodyString := string(bodyBytes)
 	assert.Equal(t, bodyString,
 		`{}
-`)
-}
-
-func TestUpdateUsers_MakesRequestWithName(t *testing.T) {
-	httpClient := &mockHTTPClient{
-		response: `{ }`,
-	}
-
-	name := "John Doe"
-	_, _ = Update(
-		httpClient, context.Background(), "https://example.com",
-		"example@oliverbinns.co.uk",
-		&name,
-		nil,
-	)
-
-	assert.Equal(t, len(httpClient.requests), 1)
-	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
-	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/example@oliverbinns.co.uk?updateMask=name")
-
-	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
-	assert.NoError(t, err)
-	bodyString := string(bodyBytes)
-	assert.Equal(t, bodyString,
-		`{"name":"John Doe"}
 `)
 }
 
@@ -69,7 +43,6 @@ func TestUpdateUsers_MakesRequestWithPermissions(t *testing.T) {
 	_, _ = Update(
 		httpClient, context.Background(), "https://example.com",
 		"example@oliverbinns.co.uk",
-		nil,
 		&permissions,
 	)
 
@@ -82,35 +55,6 @@ func TestUpdateUsers_MakesRequestWithPermissions(t *testing.T) {
 	bodyString := string(bodyBytes)
 	assert.Equal(t, bodyString,
 		`{"developerAccountPermissions":["CAN_MANAGE_PERMISSIONS_GLOBAL","CAN_REPLY_TO_REVIEWS_GLOBAL"]}
-`)
-}
-
-func TestUpdateUsers_MakesRequestWithAllParameters(t *testing.T) {
-	httpClient := &mockHTTPClient{
-		response: `{ }`,
-	}
-
-	name := "John Doe"
-	permissions := []DeveloperLevelPermission{
-		CanManagePermissionsGlobal,
-		CanReplyToReviewsGlobal,
-	}
-	_, _ = Update(
-		httpClient, context.Background(), "https://example.com",
-		"example@oliverbinns.co.uk",
-		&name,
-		&permissions,
-	)
-
-	assert.Equal(t, len(httpClient.requests), 1)
-	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
-	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com/example@oliverbinns.co.uk?updateMask=name%2CdeveloperAccountPermissions")
-
-	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
-	assert.NoError(t, err)
-	bodyString := string(bodyBytes)
-	assert.Equal(t, bodyString,
-		`{"name":"John Doe","developerAccountPermissions":["CAN_MANAGE_PERMISSIONS_GLOBAL","CAN_REPLY_TO_REVIEWS_GLOBAL"]}
 `)
 }
 
@@ -129,7 +73,6 @@ func TestUpdateUsers_DecodesResponse(t *testing.T) {
 	user, _ := Update(
 		httpClient, context.Background(), "https://example.com",
 		"mail@oliverbinns.co.uk",
-		nil,
 		nil,
 	)
 

--- a/users/update_test.go
+++ b/users/update_test.go
@@ -1,0 +1,134 @@
+package users
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateUsers_MakesRequestWithNoValues(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{ }`,
+	}
+
+	_, _ = Update(
+		httpClient, context.Background(), "https://example.com",
+		nil,
+		nil,
+	)
+
+	assert.Equal(t, len(httpClient.requests), 1)
+	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com?updateMask=")
+
+	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
+	assert.NoError(t, err)
+	bodyString := string(bodyBytes)
+	assert.Equal(t, bodyString,
+		`{}
+`)
+}
+
+func TestUpdateUsers_MakesRequestWithName(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{ }`,
+	}
+
+	name := "John Doe"
+	_, _ = Update(
+		httpClient, context.Background(), "https://example.com",
+		&name,
+		nil,
+	)
+
+	assert.Equal(t, len(httpClient.requests), 1)
+	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com?updateMask=name")
+
+	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
+	assert.NoError(t, err)
+	bodyString := string(bodyBytes)
+	assert.Equal(t, bodyString,
+		`{"name":"John Doe"}
+`)
+}
+
+func TestUpdateUsers_MakesRequestWithPermissions(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{ }`,
+	}
+
+	permissions := []DeveloperLevelPermission{
+		CanManagePermissionsGlobal,
+		CanReplyToReviewsGlobal,
+	}
+	_, _ = Update(
+		httpClient, context.Background(), "https://example.com",
+		nil,
+		&permissions,
+	)
+
+	assert.Equal(t, len(httpClient.requests), 1)
+	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com?updateMask=developerAccountPermissions")
+
+	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
+	assert.NoError(t, err)
+	bodyString := string(bodyBytes)
+	assert.Equal(t, bodyString,
+		`{"developerAccountPermissions":["CAN_MANAGE_PERMISSIONS_GLOBAL","CAN_REPLY_TO_REVIEWS_GLOBAL"]}
+`)
+}
+
+func TestUpdateUsers_MakesRequestWithAllParameters(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{ }`,
+	}
+
+	name := "John Doe"
+	permissions := []DeveloperLevelPermission{
+		CanManagePermissionsGlobal,
+		CanReplyToReviewsGlobal,
+	}
+	_, _ = Update(
+		httpClient, context.Background(), "https://example.com",
+		&name,
+		&permissions,
+	)
+
+	assert.Equal(t, len(httpClient.requests), 1)
+	assert.Equal(t, httpClient.requests[0].Method, "PATCH")
+	assert.Equal(t, httpClient.requests[0].URL.String(), "https://example.com?updateMask=name%2CdeveloperAccountPermissions")
+
+	bodyBytes, err := io.ReadAll(httpClient.requests[0].Body)
+	assert.NoError(t, err)
+	bodyString := string(bodyBytes)
+	assert.Equal(t, bodyString,
+		`{"name":"John Doe","developerAccountPermissions":["CAN_MANAGE_PERMISSIONS_GLOBAL","CAN_REPLY_TO_REVIEWS_GLOBAL"]}
+`)
+}
+
+func TestUpdateUsers_DecodesResponse(t *testing.T) {
+	httpClient := &mockHTTPClient{
+		response: `{
+			"name": "Oliver Binns",
+			"email": "mail@oliverbinns.co.uk",
+			"accessState": "ACCESS_GRANTED",
+			"partial": false,
+			"developerAccountPermissions": [ ],
+			"grants": [ ]
+		}`,
+	}
+
+	user, _ := Update(
+		httpClient, context.Background(), "https://example.com",
+		nil,
+		nil,
+	)
+
+	assert.Equal(t, user.Name, "Oliver Binns")
+	assert.Equal(t, user.Email, "mail@oliverbinns.co.uk")
+	assert.Equal(t, user.AccessState, AccessGranted)
+}

--- a/users/user.go
+++ b/users/user.go
@@ -1,10 +1,10 @@
 package users
 
 type User struct {
-	Name                       string                     `json:"name"`
-	Email                      string                     `json:"email"`
-	DeveloperAccountPermission []DeveloperLevelPermission `json:"developerAccountPermissions"`
-	Partial                    bool                       `json:"partial,omitempty"`
-	AccessState                AccessState                `json:"accessState,omitempty"`
-	PrimaryLocale              []Grant                    `json:"grants,omitempty"`
+	Name                        string                     `json:"name"`
+	Email                       string                     `json:"email"`
+	DeveloperAccountPermissions []DeveloperLevelPermission `json:"developerAccountPermissions"`
+	Partial                     bool                       `json:"partial,omitempty"`
+	AccessState                 AccessState                `json:"accessState,omitempty"`
+	Grants                      []Grant                    `json:"grants,omitempty"`
 }


### PR DESCRIPTION
Users can now be updated:

```go
user, err := r.client.UpdateUser(
	"mail@oliverbinns.co.uk"
	ctx,
	[CanPublishGamesGlobal],
) 
```