### PR TITLE
fix: remove name from create user request as this is not configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,7 +43,6 @@ func (c *Client) ListUsers(ctx context.Context) ([]users.User, error) {
 }
 
 func (c *Client) CreateUser(
-	name string,
 	email string,
 	permission []users.DeveloperLevelPermission,
 	ctx context.Context,
@@ -54,7 +53,6 @@ func (c *Client) CreateUser(
 	)
 
 	newUserRequest := users.User{
-		Name:                        name,
 		Email:                       email,
 		DeveloperAccountPermissions: permission,
 	}


### PR DESCRIPTION
See docs: https://developers.google.com/android-publisher/api-ref/rest/v3/users

This is a resource name rather than the user's name.