### PR TITLE
chore: remove a deprecated permission

### DIFF
--- a/users/developer_level_permission.go
+++ b/users/developer_level_permission.go
@@ -4,7 +4,6 @@ type DeveloperLevelPermission string
 
 const (
 	UnspecifiedDeveloperLevelPermission DeveloperLevelPermission = "DEVELOPER_LEVEL_PERMISSION_UNSPECIFIED"
-	CanSeeAllApps                       DeveloperLevelPermission = "CAN_SEE_ALL_APPS"
 	CanViewFinancialDataGlobal          DeveloperLevelPermission = "CAN_VIEW_FINANCIAL_DATA_GLOBAL"
 	CanManagePermissionsGlobal          DeveloperLevelPermission = "CAN_MANAGE_PERMISSIONS_GLOBAL"
 	CanEditGamesGlobal                  DeveloperLevelPermission = "CAN_EDIT_GAMES_GLOBAL"


### PR DESCRIPTION
`CAN_SEE_ALL_APPS` is deprecated and should be replaced with `CAN_VIEW_NON_FINANCIAL_DATA_GLOBAL`.

See Google Docs for more details: https://developers.google.com/android-publisher/api-ref/rest/v3/users#DeveloperLevelPermission