### PR TITLE
feat: app-level permission expansion map

### DIFF
--- a/users/app_level_permissions.go
+++ b/users/app_level_permissions.go
@@ -3,19 +3,60 @@ package users
 type AppLevelPermission string
 
 const (
-	UnspecifiedAppLevelPermission AppLevelPermission = "APP_LEVEL_PERMISSION_UNSPECIFIED"
-	CanAccessApp                  AppLevelPermission = "CAN_ACCESS_APP"
-	CanViewFinancialData          AppLevelPermission = "CAN_VIEW_FINANCIAL_DATA"
-	CanManagePermissions          AppLevelPermission = "CAN_MANAGE_PERMISSIONS"
-	CanReplyToReviews             AppLevelPermission = "CAN_REPLY_TO_REVIEWS"
-	CanManagePublicAPKs           AppLevelPermission = "CAN_MANAGE_PUBLIC_APKS"
-	CanManageTrackAPKs            AppLevelPermission = "CAN_MANAGE_TRACK_APKS"
-	CanManageTrackUsers           AppLevelPermission = "CAN_MANAGE_TRACK_USERS"
-	CanManagePublicListing        AppLevelPermission = "CAN_MANAGE_PUBLIC_LISTING"
-	CanManageDraftApps            AppLevelPermission = "CAN_MANAGE_DRAFT_APPS"
-	CanManageOrders               AppLevelPermission = "CAN_MANAGE_ORDERS"
-	CanManageAppContent           AppLevelPermission = "CAN_MANAGE_APP_CONTENT"
-	CanViewNonFinancialData       AppLevelPermission = "CAN_VIEW_NON_FINANCIAL_DATA"
-	CanViewAppQuality             AppLevelPermission = "CAN_VIEW_APP_QUALITY"
-	CanManageDeeplinks            AppLevelPermission = "CAN_MANAGE_DEEPLINKS"
+	CanViewFinancialData    AppLevelPermission = "CAN_VIEW_FINANCIAL_DATA"
+	CanManagePermissions    AppLevelPermission = "CAN_MANAGE_PERMISSIONS"
+	CanReplyToReviews       AppLevelPermission = "CAN_REPLY_TO_REVIEWS"
+	CanManagePublicAPKs     AppLevelPermission = "CAN_MANAGE_PUBLIC_APKS"
+	CanManageTrackAPKs      AppLevelPermission = "CAN_MANAGE_TRACK_APKS"
+	CanManageTrackUsers     AppLevelPermission = "CAN_MANAGE_TRACK_USERS"
+	CanManagePublicListing  AppLevelPermission = "CAN_MANAGE_PUBLIC_LISTING"
+	CanManageDraftApps      AppLevelPermission = "CAN_MANAGE_DRAFT_APPS"
+	CanManageOrders         AppLevelPermission = "CAN_MANAGE_ORDERS"
+	CanManageAppContent     AppLevelPermission = "CAN_MANAGE_APP_CONTENT"
+	CanViewNonFinancialData AppLevelPermission = "CAN_VIEW_NON_FINANCIAL_DATA"
+	CanViewAppQuality       AppLevelPermission = "CAN_VIEW_APP_QUALITY"
+	CanManageDeeplinks      AppLevelPermission = "CAN_MANAGE_DEEPLINKS"
 )
+
+func (permission AppLevelPermission) Expand() []AppLevelPermission {
+	switch permission {
+	case CanManagePermissions:
+		return []AppLevelPermission{
+			CanViewFinancialData,
+			CanManagePermissions,
+			CanReplyToReviews,
+			CanManagePublicAPKs,
+			CanManageTrackAPKs,
+			CanManageTrackUsers,
+			CanManagePublicListing,
+			CanManageDraftApps,
+			CanManageOrders,
+			CanManageAppContent,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+			CanManageDeeplinks,
+		}
+	case CanViewFinancialData,
+		CanReplyToReviews,
+		CanManagePublicAPKs,
+		CanManageTrackAPKs,
+		CanManageTrackUsers,
+		CanManagePublicListing,
+		CanManageDraftApps,
+		CanManageAppContent,
+		CanManageOrders,
+		CanManageDeeplinks:
+		return []AppLevelPermission{
+			permission,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		}
+	case CanViewNonFinancialData:
+		return []AppLevelPermission{
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		}
+	default:
+		return []AppLevelPermission{permission}
+	}
+}

--- a/users/app_level_permissions_test.go
+++ b/users/app_level_permissions_test.go
@@ -1,0 +1,170 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandCanManagePermissions(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanViewFinancialData,
+			CanManagePermissions,
+			CanReplyToReviews,
+			CanManagePublicAPKs,
+			CanManageTrackAPKs,
+			CanManageTrackUsers,
+			CanManagePublicListing,
+			CanManageDraftApps,
+			CanManageOrders,
+			CanManageAppContent,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+			CanManageDeeplinks,
+		},
+		CanManagePermissions.Expand(),
+	)
+}
+
+func TestExpandCanViewFinancialData(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanViewFinancialData,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanViewFinancialData.Expand(),
+	)
+}
+
+func TestExpandCanReplyToReviews(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanReplyToReviews,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanReplyToReviews.Expand(),
+	)
+}
+
+func TestExpandCanManagePublicAPKs(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanManagePublicAPKs,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanManagePublicAPKs.Expand(),
+	)
+}
+
+func TestExpandCanManageTrackAPKs(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanManageTrackAPKs,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanManageTrackAPKs.Expand(),
+	)
+}
+
+func TestExpandCanManageTrackUsers(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanManageTrackUsers,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanManageTrackUsers.Expand(),
+	)
+}
+
+func TestExpandCanManagePublicListing(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanManagePublicListing,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanManagePublicListing.Expand(),
+	)
+}
+
+func TestExpandCanManageDraftApps(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanManageDraftApps,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanManageDraftApps.Expand(),
+	)
+}
+
+func TestExpandCanManageAppContent(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanManageAppContent,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanManageAppContent.Expand(),
+	)
+}
+
+func TestExpandCanManageOrders(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanManageOrders,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanManageOrders.Expand(),
+	)
+}
+
+func TestExpandCanManageDeeplinks(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanManageDeeplinks,
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanManageDeeplinks.Expand(),
+	)
+}
+
+func TestExpandCanViewNonFinancialData(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanViewNonFinancialData,
+			CanViewAppQuality,
+		},
+		CanViewNonFinancialData.Expand(),
+	)
+}
+
+func TestExpandCanViewAppQuality(t *testing.T) {
+	assert.Equal(
+		t,
+		[]AppLevelPermission{
+			CanViewAppQuality,
+		},
+		CanViewAppQuality.Expand(),
+	)
+}


### PR DESCRIPTION
Implement expansion of App Level permissions to include those that are explicitly granted by Google. For example: `CAN_REPLY_TO_REVIEWS` also grants the user with the permissions `CAN_VIEW_NON_FINANCIAL_DATA` and `CAN_VIEW_APP_QUALITY`.