### PR TITLE
ci(fix): prevent release build from running when not required

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     name: Create GitHub tag
     runs-on: macos-15
     outputs:
-      should_release: ${{ steps.versioning.outputs.release_version }} != ""
+      should_release: ${{ steps.versioning.outputs.release_version }}
 
     steps:
       - name: Add Path Globally


### PR DESCRIPTION
Prevent builds that fill fail deployment from running.

Failing build: https://github.com/Oliver-Binns/googleplay-go/actions/runs/14650667098
Example of fixed build: https://github.com/Oliver-Binns/googleplay-go/actions/runs/14650849302