### PR TITLE
feat: developer-level permission expansion map

### DIFF
--- a/users/developer_level_permission.go
+++ b/users/developer_level_permission.go
@@ -22,3 +22,31 @@ const (
 	CanViewAppQualityGlobal             DeveloperLevelPermission = "CAN_VIEW_APP_QUALITY_GLOBAL"
 	CanManageDeeplinksGlobal            DeveloperLevelPermission = "CAN_MANAGE_DEEPLINKS_GLOBAL"
 )
+
+func (permission DeveloperLevelPermission) Expand() []DeveloperLevelPermission {
+	switch permission {
+	case CanManagePermissionsGlobal:
+		return []DeveloperLevelPermission{
+			permission,
+			CanViewFinancialDataGlobal,
+			CanEditGamesGlobal,
+			CanPublishGamesGlobal,
+			CanReplyToReviewsGlobal,
+			CanManagePublicAPKsGlobal,
+			CanManageTrackAPKsGlobal,
+			CanManageTrackUsersGlobal,
+			CanManagePublicListingGlobal,
+			CanManageDraftAppsGlobal,
+			CanCreateManagedPlayAppsGlobal,
+			CanManageOrdersGlobal,
+			CanManageAppContentGlobal,
+			CanViewNonFinancialDataGlobal,
+			CanViewAppQualityGlobal,
+			CanManageDeeplinksGlobal,
+		}
+	case CanChangeManagedPlaySettingGlobal:
+		return []DeveloperLevelPermission{}
+	default:
+		return []DeveloperLevelPermission{permission}
+	}
+}

--- a/users/developer_level_permission_test.go
+++ b/users/developer_level_permission_test.go
@@ -1,0 +1,190 @@
+package users
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandCanViewFinancialDataGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanViewFinancialDataGlobal,
+		},
+		CanViewFinancialDataGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManagePermissionsGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManagePermissionsGlobal,
+			CanViewFinancialDataGlobal,
+			CanEditGamesGlobal,
+			CanPublishGamesGlobal,
+			CanReplyToReviewsGlobal,
+			CanManagePublicAPKsGlobal,
+			CanManageTrackAPKsGlobal,
+			CanManageTrackUsersGlobal,
+			CanManagePublicListingGlobal,
+			CanManageDraftAppsGlobal,
+			CanCreateManagedPlayAppsGlobal,
+			CanManageOrdersGlobal,
+			CanManageAppContentGlobal,
+			CanViewNonFinancialDataGlobal,
+			CanViewAppQualityGlobal,
+			CanManageDeeplinksGlobal,
+		},
+		CanManagePermissionsGlobal.Expand(),
+	)
+}
+
+func TestExpandCanEditGamesGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanEditGamesGlobal,
+		},
+		CanEditGamesGlobal.Expand(),
+	)
+}
+
+func TestExpandCanPublishGamesGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanPublishGamesGlobal,
+		},
+		CanPublishGamesGlobal.Expand(),
+	)
+}
+
+func TestExpandCanReplyToReviewsGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanReplyToReviewsGlobal,
+		},
+		CanReplyToReviewsGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManagePublicAPKsGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManagePublicAPKsGlobal,
+		},
+		CanManagePublicAPKsGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManageTrackAPKsGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManageTrackAPKsGlobal,
+		},
+		CanManageTrackAPKsGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManageTrackUsersGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManageTrackUsersGlobal,
+		},
+		CanManageTrackUsersGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManagePublicListingGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManagePublicListingGlobal,
+		},
+		CanManagePublicListingGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManageDraftAppsGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManageDraftAppsGlobal,
+		},
+		CanManageDraftAppsGlobal.Expand(),
+	)
+}
+
+func TestExpandCanCreateManagedPlayAppsGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanCreateManagedPlayAppsGlobal,
+		},
+		CanCreateManagedPlayAppsGlobal.Expand(),
+	)
+}
+
+func TestExpandCanChangeManagedPlaySettingsGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{},
+		CanChangeManagedPlaySettingGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManageOrdersGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManageOrdersGlobal,
+		},
+		CanManageOrdersGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManageAppContentGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManageAppContentGlobal,
+		},
+		CanManageAppContentGlobal.Expand(),
+	)
+}
+
+func TestExpandCanViewNonFinancialDataGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanViewNonFinancialDataGlobal,
+		},
+		CanViewNonFinancialDataGlobal.Expand(),
+	)
+}
+
+func TestExpandCanViewAppQualityGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanViewAppQualityGlobal,
+		},
+		CanViewAppQualityGlobal.Expand(),
+	)
+}
+
+func TestExpandCanManageDeeplinksGlobal(t *testing.T) {
+	assert.Equal(
+		t,
+		[]DeveloperLevelPermission{
+			CanManageDeeplinksGlobal,
+		},
+		CanManageDeeplinksGlobal.Expand(),
+	)
+}


### PR DESCRIPTION
Implement the account permission level equivalent of https://github.com/Oliver-Binns/googleplay-go/pull/23.