### PR TITLE
fix!: allow non-200 HTTP status codes to be returned

### DIFF
--- a/networking/http_client.go
+++ b/networking/http_client.go
@@ -38,9 +38,5 @@ func (c *authorizedClient) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("unexpected status code %d", resp.StatusCode)
-	}
-
 	return resp, nil
 }

--- a/networking/http_client_test.go
+++ b/networking/http_client_test.go
@@ -37,19 +37,6 @@ func TestNewAuthorizedClient_Allows2XXStatusCodes(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNewAuthorizedClient_ThrowsErrorForUnexpectedStatusCode(t *testing.T) {
-	httpClient := &mockHTTPClient{
-		statusCode: http.StatusUnauthorized,
-	}
-	tokenSource := &mockTokenSource{}
-
-	authorizedClient := NewAuthorizedClient(httpClient, tokenSource)
-	req, _ := http.NewRequest("GET", "https://example.com", nil)
-	_, err := authorizedClient.Do(req)
-
-	assert.Equal(t, err.Error(), "unexpected status code 401")
-}
-
 type mockTokenSource struct{}
 
 func (c *mockTokenSource) Token() (string, error) {


### PR DESCRIPTION
Non-200 HTTP Status codes are now treated as expected responses so that servers can use 404 for resource not found.